### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ python bot.py
 ## Built With
 * [discord.py](https://github.com/Rapptz/discord.py) - API for discord
 * [baseconvert](https://github.com/squdle/baseconvert) - Convert numbers
-* [fuzzywuzzy](https://github.com/seatgeek/fuzzywuzzy) - Search quotes
+* [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) - Search quotes
 * [wolframalpha](https://github.com/jaraco/wolframalpha) - Python 3 wrapper for Wolfram|Alpha v2.0 API.
 * [ftfy](https://github.com/LuminosoInsight/python-ftfy) - Fixes glitches in Unicode text.
 * [deckofcards](https://deckofcardsapi.com/)

--- a/extensions/minecraft.py
+++ b/extensions/minecraft.py
@@ -1,7 +1,6 @@
 import discord
 from discord.ext import commands
 import json
-from fuzzywuzzy import fuzz, process
 from random import choice, shuffle
 
 class Minecraft(commands.Cog):

--- a/extensions/movies.py
+++ b/extensions/movies.py
@@ -1,7 +1,6 @@
 import discord
 from discord.ext import commands
 import json
-from fuzzywuzzy import fuzz, process
 from random import choice, shuffle
 
 class Movies(commands.Cog):

--- a/extensions/quotes.py
+++ b/extensions/quotes.py
@@ -1,7 +1,7 @@
 import discord
 from discord.ext import commands
 import json
-from fuzzywuzzy import fuzz, process
+from rapidfuzz import fuzz, process
 from random import choice, shuffle
 
 class Quotes(commands.Cog):
@@ -167,9 +167,9 @@ class Quotes(commands.Cog):
         candidates = quoteA + quote + fact
         shuffle(candidates)
         
-        result = process.extract(search, candidates, limit=1)
+        result = process.extractOne(search, candidates)
 
-        await ctx.send(result[0][0])
+        await ctx.send(result[0])
 
 def getRLine(quotes_dict, filename):
 #get a random quote

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ chardet==3.0.4
 discord==1.0.1
 discord.py==1.2.5
 ftfy==5.6
-fuzzywuzzy==0.17.0
 google-api-python-client==1.7.11
 google-auth==1.10.0
 google-auth-httplib2==0.0.3
@@ -32,7 +31,7 @@ Pillow==7.0.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pylint==2.4.4
-python-Levenshtein==0.12.0
+rapidfuzz==0.9.1
 requests==2.22.0
 requests-oauthlib==1.3.0
 rsa==4.0


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy